### PR TITLE
Adding entities, events, actions, and tests for Survey Profile

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -20,6 +20,11 @@
  * Actions
  */
 var actions = {
+  accepted: {
+    term: "Accepted",
+    iri: "http://purl.imsglobal.org/caliper/actions/Accepted",
+    events: ["event", "surveyInvitationEvent"]
+  },
   added: {
     term: "Added",
     iri: "http://purl.imsglobal.org/caliper/actions/Added",
@@ -88,7 +93,7 @@ var actions = {
   completed: {
     term: "Completed",
     iri: "http://purl.imsglobal.org/caliper/actions/Completed",
-    events: ["event", "assessmentItemEvent", "assignableEvent"]
+    events: ["event", "assessmentItemEvent", "assignableEvent", "questionnaireItemEvent"]
   },
   copied: {
     term: "Copied",
@@ -104,6 +109,11 @@ var actions = {
     term: "Deactivated",
     iri: "http://purl.imsglobal.org/caliper/actions/Deactivated",
     events: ["event", "assignableEvent"]
+  },
+  declined: {
+    term: "Declined",
+    iri: "http://purl.imsglobal.org/caliper/actions/Declined",
+    events: ["event", "surveyInvitationEvent"]
   },
   deleted: {
     term: "Deleted",
@@ -181,9 +191,9 @@ var actions = {
     events: ["event", "mediaEvent"]
   },
   launched: {
-      term: "Launched",
-      iri: "http://purl.imsglobal.org/caliper/actions/Launched",
-      events: ["event", "toolLaunchEvent"]
+    term: "Launched",
+    iri: "http://purl.imsglobal.org/caliper/actions/Launched",
+    events: ["event", "toolLaunchEvent"]
   },
   liked: {
     term: "Liked",
@@ -234,6 +244,16 @@ var actions = {
     term: "OpenedPopout",
     iri: "http://purl.imsglobal.org/caliper/actions/OpenedPopout",
     events: ["event", "mediaEvent"]
+  },
+  optedIn: {
+    term: "OptedIn",
+    iri: "http://purl.imsglobal.org/caliper/actions/OptedIn",
+    events: ["event", "surveyEvent"]
+  },
+  optedOut: {
+    term: "OptedOut",
+    iri: "http://purl.imsglobal.org/caliper/actions/OptedOut",
+    events: ["event", "surveyEvent"]
   },
   paused: {
     term: "Paused",
@@ -325,6 +345,11 @@ var actions = {
     iri: "http://purl.imsglobal.org/caliper/actions/Searched",
     events: ["event", "searchEvent"]
   },
+  sent: {
+    term: "Sent",
+    iri: "http://purl.imsglobal.org/caliper/actions/Sent",
+    events: ["event", "surveyInvitationEvent"]
+  },
   shared: {
     term: "Shared",
     iri: "http://purl.imsglobal.org/caliper/actions/Shared",
@@ -338,17 +363,18 @@ var actions = {
   skipped: {
     term: "Skipped",
     iri: "http://purl.imsglobal.org/caliper/actions/Skipped",
-    events: ["event", "assessmentItemEvent"]
+    events: ["event", "assessmentItemEvent", "questionnaireItemEvent"]
   },
   started: {
     term: "Started",
     iri: "http://purl.imsglobal.org/caliper/actions/Started",
-    events: ["event", "assessmentEvent", "assessmentItemEvent", "assignableEvent", "mediaEvent"]
+    events: ["event", "assessmentEvent", "assessmentItemEvent", "assignableEvent", "mediaEvent", "questionnaireEvent",
+             "questionnaireItemEvent"]
   },
   submitted: {
     term: "Submitted",
     iri: "http://purl.imsglobal.org/caliper/actions/Submitted",
-    events: ["event", "assessmentEvent", "assignableEvent"]
+    events: ["event", "assessmentEvent", "assignableEvent", "questionnaireEvent"]
   },
   subscribed: {
     term: "Subscribed",

--- a/src/entities/entityType.js
+++ b/src/entities/entityType.js
@@ -209,6 +209,16 @@ var entityType = {
     term: "MultipleResponseResponse",
     iri: "http://purl.imsglobal.org/caliper/MultipleResponseResponse"
   },
+  multiselectQuestion: {
+    context: config.jsonldContext.v1p1_survey,
+    term: "MultiselectQuestion",
+    iri: "http://purl.imsglobal.org/caliper/MultiselectQuestion"
+  },
+  multiselectResponse : {
+    context: config.jsonldContext.v1p1_survey,
+    term: "MultiselectResponse",
+    iri: "http://purl.imsglobal.org/caliper/MultiselectResponse"
+  },
   multiselectScale: {
     context: config.jsonldContext.v1p1_feedback,
     term: "MultiselectScale",
@@ -218,6 +228,16 @@ var entityType = {
     context: config.jsonldContext.v1p1_feedback,
     term: "NumericScale",
     iri: "http://purl.imsglobal.org/caliper/NumericScale"
+  },
+  openEndedQuestion: {
+    context: config.jsonldContext.v1p1_survey,
+    term: "OpenEndedQuestion",
+    iri: "http://purl.imsglobal.org/caliper/OpenEndedQuestion"
+  },
+  openEndedResponse: {
+    context: config.jsonldContext.v1p1_survey,
+    term: "OpenEndedResponse",
+    iri: "http://purl.imsglobal.org/caliper/OpenEndedResponse"
   },
   organization: {
     context: config.jsonldContext.v1p1,
@@ -263,6 +283,11 @@ var entityType = {
     context: config.jsonldContext.v1p1_feedback,
     term: "RatingScaleQuestion",
     iri: "http://purl.imsglobal.org/caliper/RatingScaleQuestion"
+  },
+  ratingScaleResponse: {
+    context: config.jsonldContext.v1p1_survey,
+    term: "RatingScaleResponse",
+    iri: "http://purl.imsglobal.org/caliper/RatingScaleResponse"
   },
   response: {
     context: config.jsonldContext.v1p1,
@@ -313,6 +338,11 @@ var entityType = {
     context: config.jsonldContext.v1p1_survey,
     term: "Survey",
     iri: "http://purl.imsglobal.org/caliper/Survey"
+  },
+  surveyInvitation: {
+    context: config.jsonldContext.v1p1_survey,
+    term: "SurveyInvitation",
+    iri: "http://purl.imsglobal.org/caliper/SurveyInvitation"
   },
   tagAnnotation: {
     context: config.jsonldContext.v1p1,

--- a/src/entities/question/multiselectQuestion.js
+++ b/src/entities/question/multiselectQuestion.js
@@ -1,0 +1,35 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var question = require('./question');
+var entityType = require('../entityType').multiselectQuestion;
+
+/**
+ * Link MultiselectQuestion to delegate Entity and assign default property values.
+ */
+var MultiselectQuestion = _.assign({}, question, {
+    '@context': entityType.context,
+    id: entityType.iri,
+    type: entityType.term,
+    points: null,
+    itemLabels: [],
+    itemValues: []
+});
+
+module.exports = MultiselectQuestion;

--- a/src/entities/question/openEndedQuestion.js
+++ b/src/entities/question/openEndedQuestion.js
@@ -1,0 +1,33 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var entity = require('../entity');
+var question = require('./question');
+var entityType = require('../entityType').openEndedQuestion;
+
+/**
+ * Link OpenEndedQuestion to delegate Entity and assign default property values.
+ */
+var OpenEndedQuestion = _.assign({}, question, {
+    '@context': entityType.context,
+    id: entityType.iri,
+    type: entityType.term
+});
+
+module.exports = OpenEndedQuestion;

--- a/src/entities/resource/surveyInvitation.js
+++ b/src/entities/resource/surveyInvitation.js
@@ -1,0 +1,36 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var digitalResource = require('./digitalResource');
+var entityType = require('../entityType').surveyInvitation;
+
+/**
+ * Link SurveyInvitation to delegate Entity and assign default property values.
+ */
+var SurveyInvitation = _.assign({}, digitalResource, {
+    '@context': entityType.context,
+    id: entityType.iri,
+    type: entityType.term,
+    rater: null,
+    survey: null,
+    sentCount: null,
+    sentDate: null
+});
+
+module.exports = SurveyInvitation;

--- a/src/entities/response/multiselectResponse.js
+++ b/src/entities/response/multiselectResponse.js
@@ -1,0 +1,33 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var response = require('./response');
+var entityType = require('../entityType').multiselectResponse;
+
+/**
+ * Link MultiselectResponse to delegate Response and assign default property values.
+ */
+var MultiselectResponse = _.assign({}, response, {
+  '@context': entityType.context,
+  id: entityType.iri,
+  type: entityType.term,
+  selections: []
+});
+
+module.exports = MultiselectResponse;

--- a/src/entities/response/openEndedResponse.js
+++ b/src/entities/response/openEndedResponse.js
@@ -1,0 +1,33 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var response = require('./response');
+var entityType = require('../entityType').openEndedResponse;
+
+/**
+ * Link OpenEndedResponse to delegate Response and assign default property values.
+ */
+var OpenEndedResponse = _.assign({}, response, {
+  '@context': entityType.context,
+  id: entityType.iri,
+  type: entityType.term,
+  value: null
+});
+
+module.exports = OpenEndedResponse;

--- a/src/entities/response/ratingScaleResponse.js
+++ b/src/entities/response/ratingScaleResponse.js
@@ -1,0 +1,33 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var response = require('./response');
+var entityType = require('../entityType').ratingScaleResponse;
+
+/**
+ * Link RatingScaleResponse to delegate Response and assign default property values.
+ */
+var RatingScaleResponse = _.assign({}, response, {
+  '@context': entityType.context,
+  id: entityType.iri,
+  type: entityType.term,
+  selections: []
+});
+
+module.exports = RatingScaleResponse;

--- a/src/events/eventType.js
+++ b/src/events/eventType.js
@@ -74,6 +74,16 @@ var eventType = {
     term: "NavigationEvent",
     iri: "http://purl.imsglobal.org/caliper/NavigationEvent"
   },
+  questionnaire: {
+    context: config.jsonldContext.v1p1_survey,
+    term: "QuestionnaireEvent",
+    iri: "http://purl.imsglobal.org/caliper/QuestionnaireEvent"
+  },
+  questionnaireItem: {
+    context: config.jsonldContext.v1p1_survey,
+    term: "QuestionnaireItemEvent",
+    iri: "http://purl.imsglobal.org/caliper/QuestionnaireItemEvent"
+  },
   resourceManagement: {
     context: config.jsonldContext.v1p1_resourceManagement,
     term: "ResourceManagementEvent",
@@ -88,6 +98,16 @@ var eventType = {
     context: config.jsonldContext.v1p1,
     term: "SessionEvent",
     iri: "http://purl.imsglobal.org/caliper/SessionEvent"
+  },
+  survey: {
+    context: config.jsonldContext.v1p1_survey,
+    term: "SurveyEvent",
+    iri: "http://purl.imsglobal.org/caliper/SurveyEvent"
+  },
+  surveyInvitation: {
+    context: config.jsonldContext.v1p1_survey,
+    term: "SurveyInvitationEvent",
+    iri: "http://purl.imsglobal.org/caliper/SurveyInvitationEvent"
   },
   thread: {
     context: config.jsonldContext.v1p1,

--- a/src/events/questionnaireEvent.js
+++ b/src/events/questionnaireEvent.js
@@ -1,0 +1,31 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var event = require('./event');
+var eventType = require('./eventType').questionnaire;
+
+/**
+ * Compose QuestionnaireEvent from Event and set default properties.
+ */
+var QuestionnaireEvent = _.assign({}, event, {
+  '@context': eventType.context,
+  type: eventType.term
+});
+
+module.exports = QuestionnaireEvent;

--- a/src/events/questionnaireItemEvent.js
+++ b/src/events/questionnaireItemEvent.js
@@ -1,0 +1,31 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var event = require('./event');
+var eventType = require('./eventType').questionnaireItem;
+
+/**
+ * Compose QuestionnaireItemEvent from Event and set default properties.
+ */
+var QuestionnaireItemEvent = _.assign({}, event, {
+  '@context': eventType.context,
+  type: eventType.term
+});
+
+module.exports = QuestionnaireItemEvent;

--- a/src/events/surveyEvent.js
+++ b/src/events/surveyEvent.js
@@ -1,0 +1,31 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var event = require('./event');
+var eventType = require('./eventType').survey;
+
+/**
+ * Compose SurveyEvent from Event and set default properties.
+ */
+var SurveyEvent = _.assign({}, event, {
+  '@context': eventType.context,
+  type: eventType.term
+});
+
+module.exports = SurveyEvent;

--- a/src/events/surveyInvitationEvent.js
+++ b/src/events/surveyInvitationEvent.js
@@ -1,0 +1,31 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var event = require('./event');
+var eventType = require('./eventType').surveyInvitation;
+
+/**
+ * Compose SurveyInvitationEvent from Event and set default properties.
+ */
+var SurveyInvitationEvent = _.assign({}, event, {
+  '@context': eventType.context,
+  type: eventType.term
+});
+
+module.exports = SurveyInvitationEvent;

--- a/src/sensor.js
+++ b/src/sensor.js
@@ -236,33 +236,33 @@ Caliper.Config.Config                      = require('./config/config');
 Caliper.Config.Contexts                    = require('./config/contexts');
 
 // Entities
-Caliper.Entities.Entity                   = require('./entities/entity');
-Caliper.Entities.EntityFactory            = require('./entities/entityFactory');
-Caliper.Entities.EntityType               = require('./entities/entityType');
+Caliper.Entities.Entity                    = require('./entities/entity');
+Caliper.Entities.EntityFactory             = require('./entities/entityFactory');
+Caliper.Entities.EntityType                = require('./entities/entityType');
 
 // Agents
-Caliper.Entities.Agent                    = require('./entities/agent/agent');
-Caliper.Entities.Person                   = require('./entities/agent/person');
-Caliper.Entities.SoftwareApplication      = require('./entities/agent/softwareApplication');
+Caliper.Entities.Agent                     = require('./entities/agent/agent');
+Caliper.Entities.Person                    = require('./entities/agent/person');
+Caliper.Entities.SoftwareApplication       = require('./entities/agent/softwareApplication');
 
 // Agents (Organizations)
-Caliper.Entities.CourseOffering           = require('./entities/agent/courseOffering');
-Caliper.Entities.CourseSection            = require('./entities/agent/courseSection');
-Caliper.Entities.Group                    = require('./entities/agent/group');
-Caliper.Entities.Membership               = require('./entities/agent/membership');
-Caliper.Entities.Organization             = require('./entities/agent/organization');
-Caliper.Entities.Role                     = require('./entities/agent/role');
-Caliper.Entities.Status                   = require('./entities/agent/status');
+Caliper.Entities.CourseOffering            = require('./entities/agent/courseOffering');
+Caliper.Entities.CourseSection             = require('./entities/agent/courseSection');
+Caliper.Entities.Group                     = require('./entities/agent/group');
+Caliper.Entities.Membership                = require('./entities/agent/membership');
+Caliper.Entities.Organization              = require('./entities/agent/organization');
+Caliper.Entities.Role                      = require('./entities/agent/role');
+Caliper.Entities.Status                    = require('./entities/agent/status');
 
 // Annotations
-Caliper.Entities.Annotation               = require('./entities/annotation/annotation');
-Caliper.Entities.BookmarkAnnotation       = require('./entities/annotation/bookmarkAnnotation');
-Caliper.Entities.HighlightAnnotation      = require('./entities/annotation/highlightAnnotation');
-Caliper.Entities.SharedAnnotation         = require('./entities/annotation/sharedAnnotation');
-Caliper.Entities.TagAnnotation            = require('./entities/annotation/tagAnnotation');
+Caliper.Entities.Annotation                = require('./entities/annotation/annotation');
+Caliper.Entities.BookmarkAnnotation        = require('./entities/annotation/bookmarkAnnotation');
+Caliper.Entities.HighlightAnnotation       = require('./entities/annotation/highlightAnnotation');
+Caliper.Entities.SharedAnnotation          = require('./entities/annotation/sharedAnnotation');
+Caliper.Entities.TagAnnotation             = require('./entities/annotation/tagAnnotation');
 
 // Assignment-related
-Caliper.Entities.LearningObjective        = require('./entities/resource/learningObjective');
+Caliper.Entities.LearningObjective         = require('./entities/resource/learningObjective');
 
 // Resources
 Caliper.Entities.Assessment                = require('./entities/resource/assessment');
@@ -282,8 +282,9 @@ Caliper.Entities.MediaObject               = require('./entities/resource/mediaO
 Caliper.Entities.MediaLocation             = require('./entities/resource/mediaLocation');
 Caliper.Entities.Message                   = require('./entities/resource/message');
 Caliper.Entities.Page                      = require('./entities/resource/page');
-Caliper.Entities.Questionnaire             = require('./entities/resource/questionnaire')
-Caliper.Entities.QuestionnaireItem         = require('./entities/resource/questionnaireItem')
+Caliper.Entities.Questionnaire             = require('./entities/resource/questionnaire');
+Caliper.Entities.QuestionnaireItem         = require('./entities/resource/questionnaireItem');
+Caliper.Entities.SurveyInvitation          = require('./entities/resource/surveyInvitation');
 Caliper.Entities.Thread                    = require('./entities/resource/thread');
 Caliper.Entities.VideoObject               = require('./entities/resource/videoObject');
 Caliper.Entities.WebPage                   = require('./entities/resource/webPage');
@@ -296,7 +297,9 @@ Caliper.Entities.Score                     = require('./entities/outcome/score')
 // Question
 Caliper.Entities.Question                  = require('./entities/question/question');
 Caliper.Entities.DateTimeQuestion          = require('./entities/question/dateTimeQuestion');
+Caliper.Entities.MultiselectQuestion       = require('./entities/question/multiselectQuestion');
 Caliper.Entities.RatingScaleQuestion       = require('./entities/question/ratingScaleQuestion');
+Caliper.Entities.OpenEndedQuestion         = require('./entities/question/openEndedQuestion');
 
 // Response
 Caliper.Entities.Response                  = require('./entities/response/response');
@@ -304,6 +307,9 @@ Caliper.Entities.DateTimeResponse          = require('./entities/response/dateTi
 Caliper.Entities.FillinBlankResponse       = require('./entities/response/fillinBlankResponse');
 Caliper.Entities.MultipleChoiceResponse    = require('./entities/response/multipleChoiceResponse');
 Caliper.Entities.MultipleResponseResponse  = require('./entities/response/multipleResponseResponse');
+Caliper.Entities.MultiselectResponse       = require('./entities/response/multiselectResponse');
+Caliper.Entities.OpenEndedResponse         = require('./entities/response/openEndedResponse');
+Caliper.Entities.RatingScaleResponse       = require('./entities/response/ratingScaleResponse');
 Caliper.Entities.SelectTextResponse        = require('./entities/response/selectTextResponse');
 Caliper.Entities.TrueFalseResponse         = require('./entities/response/trueFalseResponse');
 
@@ -312,13 +318,13 @@ Caliper.Entities.Query                     = require('./entities/search/query');
 Caliper.Entities.SearchResponse            = require('./entities/search/searchResponse');
 
 // Survey
-Caliper.Entities.Comment                    = require('./entities/survey/comment');
-Caliper.Entities.LikertScale                = require('./entities/survey/likertScale');
-Caliper.Entities.MultiselectScale           = require('./entities/survey/multiselectScale');
-Caliper.Entities.NumericScale               = require('./entities/survey/numericScale');
-Caliper.Entities.Rating                     = require('./entities/survey/rating');
-Caliper.Entities.Scale                      = require('./entities/survey/scale');
-Caliper.Entities.Survey                     = require('./entities/survey/survey');
+Caliper.Entities.Comment                   = require('./entities/survey/comment');
+Caliper.Entities.LikertScale               = require('./entities/survey/likertScale');
+Caliper.Entities.MultiselectScale          = require('./entities/survey/multiselectScale');
+Caliper.Entities.NumericScale              = require('./entities/survey/numericScale');
+Caliper.Entities.Rating                    = require('./entities/survey/rating');
+Caliper.Entities.Scale                     = require('./entities/survey/scale');
+Caliper.Entities.Survey                    = require('./entities/survey/survey');
 
 // Session
 Caliper.Entities.Session                   = require('./entities/session/session');
@@ -343,9 +349,13 @@ Caliper.Events.MediaEvent                  = require('./events/mediaEvent');
 Caliper.Events.MessageEvent                = require('./events/messageEvent');
 Caliper.Events.NavigationEvent             = require('./events/navigationEvent');
 Caliper.Events.GradeEvent                  = require('./events/gradeEvent');
+Caliper.Events.QuestionnaireEvent          = require('./events/questionnaireEvent');
+Caliper.Events.QuestionnaireItemEvent      = require('./events/questionnaireItemEvent');
 Caliper.Events.ResourceManagementEvent     = require('./events/resourceManagementEvent');
 Caliper.Events.SearchEvent                 = require('./events/searchEvent');
 Caliper.Events.SessionEvent                = require('./events/sessionEvent');
+Caliper.Events.SurveyEvent                 = require('./events/surveyEvent');
+Caliper.Events.SurveyInvitationEvent       = require('./events/surveyInvitationEvent');
 Caliper.Events.ThreadEvent                 = require('./events/threadEvent');
 Caliper.Events.ToolLaunchEvent             = require('./events/toolLaunchEvent');
 Caliper.Events.ToolUseEvent                = require('./events/toolUseEvent');

--- a/test/entities/multiselectQuestionTest.js
+++ b/test/entities/multiselectQuestionTest.js
@@ -22,43 +22,34 @@ var test = require('tape');
 
 var config = require('../../src/config/config');
 var entityFactory = require('../../src/entities/entityFactory');
-var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
-var RatingScaleQuestion = require('../../src/entities/question/ratingScaleQuestion');
-var LikertScale = require('../../src/entities/survey/likertScale');
+var MultiselectQuestion = require('../../src/entities/question/multiselectQuestion');
 
 var clientUtils = require('../../src/clients/clientUtils');
 var testUtils = require('../testUtils');
 
-var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityQuestionnaireItem.json';
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityMultiselectQuestion.json';
 
 testUtils.readFile(path, function(err, fixture) {
   if (err) throw err;
 
-  test('questionnaireItemTest', function (t) {
+  test('multiselectQuestionTest', function (t) {
 
     // Plan for N assertions
     t.plan(1);
 
     var BASE_EDU_IRI = 'https://example.edu';
 
-    var sampleLikertScale = entityFactory().create(LikertScale, {
-        id: BASE_EDU_IRI.concat('/scale/2'),
-        scalePoints: 4,
-        itemLabels: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
-        itemValues: ['-2', '-1', '1', '2']
-    });
-
-    var sampleRatingScaleQuestion = entityFactory().create(RatingScaleQuestion, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/question'),
-        questionPosed: 'How satisfied are you with our services?',
-        scale: sampleLikertScale,
-    });
-
-    var entity = entityFactory().create(QuestionnaireItem, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1'),
-        question: sampleRatingScaleQuestion,
-        categories: ['teaching effectiveness', 'Course structure'],
-        weight: 1.0
+    var entity = entityFactory().create(MultiselectQuestion, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/4/question'),
+        questionPosed: 'What do you want to study today?',
+        points: 4,
+        itemLabels: ['Calculus', 'Number theory', 'Combinatorics', 'Algebra'],
+        itemValues: [
+            'https://example.edu/terms/201801/courses/7/sections/1/objectives/1',
+            'https://example.edu/terms/201801/courses/7/sections/1/objectives/2',
+            'https://example.edu/terms/201801/courses/7/sections/1/objectives/3',
+            'https://example.edu/terms/201801/courses/7/sections/1/objectives/4'
+        ]
     });
 
     // Compare

--- a/test/entities/multiselectResponseTest.js
+++ b/test/entities/multiselectResponseTest.js
@@ -22,43 +22,33 @@ var test = require('tape');
 
 var config = require('../../src/config/config');
 var entityFactory = require('../../src/entities/entityFactory');
-var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
-var RatingScaleQuestion = require('../../src/entities/question/ratingScaleQuestion');
-var LikertScale = require('../../src/entities/survey/likertScale');
+var MultiselectResponse = require('../../src/entities/response/multiselectResponse');
 
 var clientUtils = require('../../src/clients/clientUtils');
 var testUtils = require('../testUtils');
 
-var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityQuestionnaireItem.json';
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityMultiselectResponse.json';
 
 testUtils.readFile(path, function(err, fixture) {
   if (err) throw err;
 
-  test('questionnaireItemTest', function (t) {
+  test('multiselectResponseTest', function (t) {
 
     // Plan for N assertions
     t.plan(1);
 
     var BASE_EDU_IRI = 'https://example.edu';
 
-    var sampleLikertScale = entityFactory().create(LikertScale, {
-        id: BASE_EDU_IRI.concat('/scale/2'),
-        scalePoints: 4,
-        itemLabels: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
-        itemValues: ['-2', '-1', '1', '2']
-    });
-
-    var sampleRatingScaleQuestion = entityFactory().create(RatingScaleQuestion, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/question'),
-        questionPosed: 'How satisfied are you with our services?',
-        scale: sampleLikertScale,
-    });
-
-    var entity = entityFactory().create(QuestionnaireItem, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1'),
-        question: sampleRatingScaleQuestion,
-        categories: ['teaching effectiveness', 'Course structure'],
-        weight: 1.0
+    var entity = entityFactory().create(MultiselectResponse, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/5/users/554433/responses/5'),
+        selections: [
+          'https://example.edu/terms/201801/courses/7/sections/1/objectives/1',
+          'https://example.edu/terms/201801/courses/7/sections/1/objectives/2'
+        ],
+        startedAtTime: '2018-08-01T05:55:48.000Z',
+        endedAtTime: '2018-08-01T06:00:00.000Z',
+        duration: 'PT4M12S',
+        dateCreated: '2018-08-01T06:00:00.000Z'
     });
 
     // Compare

--- a/test/entities/openEndedQuestionTest.js
+++ b/test/entities/openEndedQuestionTest.js
@@ -22,43 +22,26 @@ var test = require('tape');
 
 var config = require('../../src/config/config');
 var entityFactory = require('../../src/entities/entityFactory');
-var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
-var RatingScaleQuestion = require('../../src/entities/question/ratingScaleQuestion');
-var LikertScale = require('../../src/entities/survey/likertScale');
+var OpenEndedQuestion = require('../../src/entities/question/OpenEndedQuestion');
 
 var clientUtils = require('../../src/clients/clientUtils');
 var testUtils = require('../testUtils');
 
-var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityQuestionnaireItem.json';
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityOpenEndedQuestion.json';
 
 testUtils.readFile(path, function(err, fixture) {
   if (err) throw err;
 
-  test('questionnaireItemTest', function (t) {
+  test('openEndedQuestionTest', function (t) {
 
     // Plan for N assertions
     t.plan(1);
 
     var BASE_EDU_IRI = 'https://example.edu';
 
-    var sampleLikertScale = entityFactory().create(LikertScale, {
-        id: BASE_EDU_IRI.concat('/scale/2'),
-        scalePoints: 4,
-        itemLabels: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
-        itemValues: ['-2', '-1', '1', '2']
-    });
-
-    var sampleRatingScaleQuestion = entityFactory().create(RatingScaleQuestion, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/question'),
-        questionPosed: 'How satisfied are you with our services?',
-        scale: sampleLikertScale,
-    });
-
-    var entity = entityFactory().create(QuestionnaireItem, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1'),
-        question: sampleRatingScaleQuestion,
-        categories: ['teaching effectiveness', 'Course structure'],
-        weight: 1.0
+    var entity = entityFactory().create(OpenEndedQuestion, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/2/question'),
+        questionPosed: 'What would you change about your course?'
     });
 
     // Compare

--- a/test/entities/openEndedResponseTest.js
+++ b/test/entities/openEndedResponseTest.js
@@ -22,43 +22,30 @@ var test = require('tape');
 
 var config = require('../../src/config/config');
 var entityFactory = require('../../src/entities/entityFactory');
-var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
-var RatingScaleQuestion = require('../../src/entities/question/ratingScaleQuestion');
-var LikertScale = require('../../src/entities/survey/likertScale');
+var OpenEndedResponse = require('../../src/entities/response/OpenEndedResponse');
 
 var clientUtils = require('../../src/clients/clientUtils');
 var testUtils = require('../testUtils');
 
-var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityQuestionnaireItem.json';
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityOpenEndedResponse.json';
 
 testUtils.readFile(path, function(err, fixture) {
   if (err) throw err;
 
-  test('questionnaireItemTest', function (t) {
+  test('openEndedResponseTest', function (t) {
 
     // Plan for N assertions
     t.plan(1);
 
     var BASE_EDU_IRI = 'https://example.edu';
 
-    var sampleLikertScale = entityFactory().create(LikertScale, {
-        id: BASE_EDU_IRI.concat('/scale/2'),
-        scalePoints: 4,
-        itemLabels: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
-        itemValues: ['-2', '-1', '1', '2']
-    });
-
-    var sampleRatingScaleQuestion = entityFactory().create(RatingScaleQuestion, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/question'),
-        questionPosed: 'How satisfied are you with our services?',
-        scale: sampleLikertScale,
-    });
-
-    var entity = entityFactory().create(QuestionnaireItem, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1'),
-        question: sampleRatingScaleQuestion,
-        categories: ['teaching effectiveness', 'Course structure'],
-        weight: 1.0
+    var entity = entityFactory().create(OpenEndedResponse, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/2/users/554433/responses/2'),
+        value: 'I feel that ...',
+        startedAtTime: '2018-08-01T05:55:48.000Z',
+        endedAtTime: '2018-08-01T06:00:00.000Z',
+        duration: 'PT4M12S',
+        dateCreated: '2018-08-01T06:00:00.000Z'
     });
 
     // Compare

--- a/test/entities/questionTest.js
+++ b/test/entities/questionTest.js
@@ -20,45 +20,28 @@ var _ = require('lodash');
 var moment = require('moment');
 var test = require('tape');
 
-var config = require('../../src/config/config');
+var config =  require('../../src/config/config');
 var entityFactory = require('../../src/entities/entityFactory');
-var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
-var RatingScaleQuestion = require('../../src/entities/question/ratingScaleQuestion');
-var LikertScale = require('../../src/entities/survey/likertScale');
+var Question = require('../../src/entities/question/question');
 
 var clientUtils = require('../../src/clients/clientUtils');
 var testUtils = require('../testUtils');
 
-var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityQuestionnaireItem.json';
+var path = config.testFixturesBaseDir.v1p1 + "caliperEntityQuestion.json";
 
 testUtils.readFile(path, function(err, fixture) {
   if (err) throw err;
 
-  test('questionnaireItemTest', function (t) {
+  test('questionTest', function (t) {
 
     // Plan for N assertions
     t.plan(1);
 
     var BASE_EDU_IRI = 'https://example.edu';
 
-    var sampleLikertScale = entityFactory().create(LikertScale, {
-        id: BASE_EDU_IRI.concat('/scale/2'),
-        scalePoints: 4,
-        itemLabels: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
-        itemValues: ['-2', '-1', '1', '2']
-    });
-
-    var sampleRatingScaleQuestion = entityFactory().create(RatingScaleQuestion, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/question'),
-        questionPosed: 'How satisfied are you with our services?',
-        scale: sampleLikertScale,
-    });
-
-    var entity = entityFactory().create(QuestionnaireItem, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1'),
-        question: sampleRatingScaleQuestion,
-        categories: ['teaching effectiveness', 'Course structure'],
-        weight: 1.0
+    var entity = entityFactory().create(Question, {
+      id: BASE_EDU_IRI + '/question/1',
+      questionPosed: 'How would you rate this?'
     });
 
     // Compare

--- a/test/entities/ratingScaleQuestionTest.js
+++ b/test/entities/ratingScaleQuestionTest.js
@@ -22,19 +22,18 @@ var test = require('tape');
 
 var config = require('../../src/config/config');
 var entityFactory = require('../../src/entities/entityFactory');
-var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
-var RatingScaleQuestion = require('../../src/entities/question/ratingScaleQuestion');
-var LikertScale = require('../../src/entities/survey/likertScale');
+var RatingScaleQuestion = require('../../src/entities/question/RatingScaleQuestion');
+var LikertScale = require('../../src/entities/survey/likertScale')
 
 var clientUtils = require('../../src/clients/clientUtils');
 var testUtils = require('../testUtils');
 
-var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityQuestionnaireItem.json';
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityRatingScaleQuestion.json';
 
 testUtils.readFile(path, function(err, fixture) {
   if (err) throw err;
 
-  test('questionnaireItemTest', function (t) {
+  test('ratingScaleQuestionTest', function (t) {
 
     // Plan for N assertions
     t.plan(1);
@@ -45,20 +44,14 @@ testUtils.readFile(path, function(err, fixture) {
         id: BASE_EDU_IRI.concat('/scale/2'),
         scalePoints: 4,
         itemLabels: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
-        itemValues: ['-2', '-1', '1', '2']
+        itemValues: ['-2', '-1', '1', '2'],
+        dateCreated: '2018-08-01T06:00:00.000Z'
     });
 
-    var sampleRatingScaleQuestion = entityFactory().create(RatingScaleQuestion, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/question'),
-        questionPosed: 'How satisfied are you with our services?',
-        scale: sampleLikertScale,
-    });
-
-    var entity = entityFactory().create(QuestionnaireItem, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1'),
-        question: sampleRatingScaleQuestion,
-        categories: ['teaching effectiveness', 'Course structure'],
-        weight: 1.0
+    var entity = entityFactory().create(RatingScaleQuestion, {
+        id: BASE_EDU_IRI.concat('/question/2'),
+        questionPosed: 'Do you agree with the opinion presented?',
+        scale: sampleLikertScale
     });
 
     // Compare

--- a/test/entities/ratingScaleResponseTest.js
+++ b/test/entities/ratingScaleResponseTest.js
@@ -22,43 +22,30 @@ var test = require('tape');
 
 var config = require('../../src/config/config');
 var entityFactory = require('../../src/entities/entityFactory');
-var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
-var RatingScaleQuestion = require('../../src/entities/question/ratingScaleQuestion');
-var LikertScale = require('../../src/entities/survey/likertScale');
+var RatingScaleResponse = require('../../src/entities/response/ratingScaleResponse');
 
 var clientUtils = require('../../src/clients/clientUtils');
 var testUtils = require('../testUtils');
 
-var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityQuestionnaireItem.json';
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityRatingScaleResponse.json';
 
 testUtils.readFile(path, function(err, fixture) {
   if (err) throw err;
 
-  test('questionnaireItemTest', function (t) {
+  test('ratingScaleResponseTest', function (t) {
 
     // Plan for N assertions
     t.plan(1);
 
     var BASE_EDU_IRI = 'https://example.edu';
 
-    var sampleLikertScale = entityFactory().create(LikertScale, {
-        id: BASE_EDU_IRI.concat('/scale/2'),
-        scalePoints: 4,
-        itemLabels: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
-        itemValues: ['-2', '-1', '1', '2']
-    });
-
-    var sampleRatingScaleQuestion = entityFactory().create(RatingScaleQuestion, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/question'),
-        questionPosed: 'How satisfied are you with our services?',
-        scale: sampleLikertScale,
-    });
-
-    var entity = entityFactory().create(QuestionnaireItem, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1'),
-        question: sampleRatingScaleQuestion,
-        categories: ['teaching effectiveness', 'Course structure'],
-        weight: 1.0
+    var entity = entityFactory().create(RatingScaleResponse, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/users/554433/responses/1'),
+        selections: ['Satisfied'],
+        startedAtTime: '2018-08-01T05:55:48.000Z',
+        endedAtTime: '2018-08-01T06:00:00.000Z',
+        duration: 'PT4M12S',
+        dateCreated: '2018-08-01T06:00:00.000Z'
     });
 
     // Compare

--- a/test/entities/responseTest.js
+++ b/test/entities/responseTest.js
@@ -1,0 +1,91 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var moment = require('moment');
+var test = require('tape');
+
+var config =  require('../../src/config/config');
+var entityFactory = require('../../src/entities/entityFactory');
+var Assessment = require('../../src/entities/resource/assessment');
+var AssessmentItem = require('../../src/entities/resource/assessmentItem');
+var Attempt = require('../../src/entities/outcome/attempt');
+var Response = require('../../src/entities/response/response');
+
+var clientUtils = require('../../src/clients/clientUtils');
+var testUtils = require('../testUtils');
+
+var path = config.testFixturesBaseDir.v1p1 + "caliperEntityResponseExtended.json";
+
+testUtils.readFile(path, function(err, fixture) {
+  if (err) throw err;
+
+  test('responseTest', function (t) {
+
+    // Plan for N assertions
+    t.plan(1);
+
+    var BASE_EDU_IRI = 'https://example.edu';
+
+    var sampleAssessment = entityFactory().create(Assessment, {
+      id: BASE_EDU_IRI.concat('/terms/201601/courses/7/sections/1/assess/1')
+    });
+
+    var sampleAssessmentItem = entityFactory().create(AssessmentItem, {
+      id: BASE_EDU_IRI.concat('/terms/201601/courses/7/sections/1/assess/1/items/6'),
+      isPartOf: sampleAssessment,
+      dateCreated: '2016-08-01T06:00:00.000Z',
+      datePublished: '2016-08-15T09:30:00.000Z',
+      isTimeDependent: false,
+      maxAttempts: 2,
+      maxScore: 5.0,
+      maxSubmits: 2,
+      extensions: {
+        questionType: 'Short Answer',
+        questionText: 'Define a Caliper Event and provide examples.'
+      }
+    });
+
+    var sampleAttempt = entityFactory().create(Attempt, {
+      id: BASE_EDU_IRI.concat('/terms/201601/courses/7/sections/1/assess/1/items/6/users/554433/attempts/1'),
+      assignee: 'https://example.edu/users/554433',
+      assignable: sampleAssessmentItem,
+      count: 1,
+      startedAtTime: '2016-11-15T10:15:46.000Z',
+      endedAtTime: '2016-11-15T10:17:20.000Z'
+    });
+
+    var entity = entityFactory().create(Response, {
+      id: BASE_EDU_IRI.concat('/terms/201601/courses/7/sections/1/assess/1/items/6/users/554433/responses/1'),
+      attempt: sampleAttempt,
+      dateCreated: '2016-11-15T10:15:46.000Z',
+      startedAtTime: '2016-11-15T10:15:46.000Z',
+      endedAtTime: '2016-11-15T10:17:20.000Z',
+      extensions: {
+        value: 'A Caliper Event describes a relationship established between an actor and an object.  The relationship is formed as a result of a purposeful action undertaken by the actor in connection to the object at a particular moment. A learner starting an assessment, annotating a reading, pausing a video, or posting a message to a forum, are examples of learning activities that Caliper models as events.'
+      }
+    });
+
+    // Compare
+    var diff = testUtils.compare(fixture, clientUtils.parse(entity));
+    var diffMsg = 'Validate JSON' + (!_.isUndefined(diff) ? ' diff = ' + clientUtils.stringify(diff) : '');
+
+    t.equal(true, _.isUndefined(diff), diffMsg);
+    //t.end();
+  });
+});

--- a/test/entities/surveyInvitationTest.js
+++ b/test/entities/surveyInvitationTest.js
@@ -22,43 +22,35 @@ var test = require('tape');
 
 var config = require('../../src/config/config');
 var entityFactory = require('../../src/entities/entityFactory');
-var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
-var RatingScaleQuestion = require('../../src/entities/question/ratingScaleQuestion');
-var LikertScale = require('../../src/entities/survey/likertScale');
+var Person = require('../../src/entities/agent/person');
+var Survey = require('../../src/entities/survey/survey');
+var SurveyInvitation = require('../../src/entities/resource/SurveyInvitation');
 
 var clientUtils = require('../../src/clients/clientUtils');
 var testUtils = require('../testUtils');
 
-var path = config.testFixturesBaseDir.v1p1 + 'caliperEntityQuestionnaireItem.json';
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEntitySurveyInvitation.json';
 
 testUtils.readFile(path, function(err, fixture) {
   if (err) throw err;
 
-  test('questionnaireItemTest', function (t) {
+  test('surveyInvitationTest', function (t) {
 
     // Plan for N assertions
     t.plan(1);
 
     var BASE_EDU_IRI = 'https://example.edu';
 
-    var sampleLikertScale = entityFactory().create(LikertScale, {
-        id: BASE_EDU_IRI.concat('/scale/2'),
-        scalePoints: 4,
-        itemLabels: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
-        itemValues: ['-2', '-1', '1', '2']
-    });
+    var samplePerson = entityFactory().create(Person, {id: 'https://example.edu/users/554433'});
+    var sampleSurvey = entityFactory().create(Survey, {id: 'https://example.edu/survey/1'});
 
-    var sampleRatingScaleQuestion = entityFactory().create(RatingScaleQuestion, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/question'),
-        questionPosed: 'How satisfied are you with our services?',
-        scale: sampleLikertScale,
-    });
-
-    var entity = entityFactory().create(QuestionnaireItem, {
-        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1'),
-        question: sampleRatingScaleQuestion,
-        categories: ['teaching effectiveness', 'Course structure'],
-        weight: 1.0
+    var entity = entityFactory().create(SurveyInvitation, {
+        id: BASE_EDU_IRI.concat('/surveys/100/invitations/users/112233'),
+        sentCount: 1,
+        dateSent: '2018-11-15T10:05:00.000Z',
+        rater: samplePerson,
+        survey: sampleSurvey,
+        dateCreated: '2018-08-01T06:00:00.000Z'
     });
 
     // Compare

--- a/test/events/questionnaireEventStartedTest.js
+++ b/test/events/questionnaireEventStartedTest.js
@@ -1,0 +1,113 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var moment = require('moment');
+var test = require('tape');
+
+var config = require('../../src/config/config');
+var eventFactory = require('../../src/events/eventFactory');
+var QuestionnaireEvent = require('../../src/events/questionnaireEvent');
+var actions = require('../../src/actions/actions');
+
+var entityFactory = require('../../src/entities/entityFactory');
+var CourseSection = require('../../src/entities/agent/courseSection');
+var Membership = require('../../src/entities/agent/membership');
+var Person = require('../../src/entities/agent/person');
+var Questionnaire = require('../../src/entities/resource/questionnaire');
+var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
+var Role = require('../../src/entities/agent/role');
+var Session = require('../../src/entities/session/session');
+var Status = require('../../src/entities/agent/status');
+
+var clientUtils = require('../../src/clients/clientUtils');
+var testUtils = require('../testUtils');
+
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEventQuestionnaireStarted.json';
+
+testUtils.readFile(path, function(err, fixture) {
+  if (err) throw err;
+
+  test('questionnaireEventStartedTest', function (t) {
+
+    // Plan for N assertions
+    t.plan(1);
+
+    var BASE_EDU_IRI = 'https://example.edu';
+
+    // Person (actor)
+    var samplePerson = entityFactory().create(Person, {id: BASE_EDU_IRI.concat('/users/554433')});
+
+    // Questionnaire and QuestionnaireItems (object)
+    var questionnaireItemOne = entityFactory().create(QuestionnaireItem, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1')
+    });
+    var questionnaireItemTwo = entityFactory().create(QuestionnaireItem, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/2')
+    });
+
+    var sampleQuestionnaire = entityFactory().create(Questionnaire, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30'),
+        items: [questionnaireItemOne, questionnaireItemTwo],
+        dateCreated: '2018-08-01T06:00:00.000Z'
+    });
+
+    // CourseSection (group)
+    var sampleCourseSection = entityFactory().create(CourseSection, {
+      id: BASE_EDU_IRI.concat('/terms/201801/courses/7/sections/1'),
+      courseNumber: 'CPS 435-01',
+      academicSession: 'Fall 2018'
+    });
+
+    // Membership
+    var sampleMembership = entityFactory().create(Membership, {
+      id: sampleCourseSection.id.concat('/rosters/1'),
+      member: samplePerson.id,
+      organization: sampleCourseSection.id,
+      roles: [Role.learner.term],
+      status: Status.active.term,
+      dateCreated: '2018-08-01T06:00:00.000Z'
+    });
+
+    // Session
+    var sampleSession = entityFactory().create(Session, {
+      id: BASE_EDU_IRI.concat('/sessions/f095bbd391ea4a5dd639724a40b606e98a631823'),
+      startedAtTime: '2018-11-12T10:00:00.000Z'
+    });
+
+    // Event
+    var event = eventFactory().create(QuestionnaireEvent, {
+      id: 'urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93',
+      actor: samplePerson,
+      action: actions.started.term,
+      object: sampleQuestionnaire,
+      eventTime: '2018-11-12T10:15:00.000Z',
+      edApp: BASE_EDU_IRI,
+      group: sampleCourseSection,
+      membership: sampleMembership,
+      session: sampleSession
+    });
+
+    // Compare
+    var diff = testUtils.compare(fixture, clientUtils.parse(event));
+    var diffMsg = 'Validate JSON' + (!_.isUndefined(diff) ? ' diff = ' + clientUtils.stringify(diff) : '');
+
+    t.equal(true, _.isUndefined(diff), diffMsg);
+    //t.end();
+  });
+});

--- a/test/events/questionnaireItemEventStartedTest.js
+++ b/test/events/questionnaireItemEventStartedTest.js
@@ -1,0 +1,121 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var moment = require('moment');
+var test = require('tape');
+
+var config = require('../../src/config/config');
+var eventFactory = require('../../src/events/eventFactory');
+var QuestionnaireItemEvent = require('../../src/events/questionnaireItemEvent');
+var actions = require('../../src/actions/actions');
+
+var entityFactory = require('../../src/entities/entityFactory');
+var CourseSection = require('../../src/entities/agent/courseSection');
+var LikertScale = require('../../src/entities/survey/likertScale');
+var Membership = require('../../src/entities/agent/membership');
+var Person = require('../../src/entities/agent/person');
+var RatingScaleQuestion = require('../../src/entities/question/ratingScaleQuestion');
+var QuestionnaireItem = require('../../src/entities/resource/questionnaireItem');
+var Role = require('../../src/entities/agent/role');
+var Session = require('../../src/entities/session/session');
+var Status = require('../../src/entities/agent/status');
+
+var clientUtils = require('../../src/clients/clientUtils');
+var testUtils = require('../testUtils');
+
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEventQuestionnaireItemStarted.json';
+
+testUtils.readFile(path, function(err, fixture) {
+  if (err) throw err;
+
+  test('questionnaireItemEventStartedTest', function (t) {
+
+    // Plan for N assertions
+    t.plan(1);
+
+    var BASE_EDU_IRI = 'https://example.edu';
+
+    // Person (actor)
+    var samplePerson = entityFactory().create(Person, {id: BASE_EDU_IRI.concat('/users/554433')});
+
+    // QuestionnaireItem, RatingScaleQuestion, and LikertScale (object)
+    var sampleLikertScale = entityFactory().create(LikertScale, {
+        id: BASE_EDU_IRI.concat('/scale/2'),
+        scalePoints: 4,
+        itemLabels: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
+        itemValues: ['-2', '-1', '1', '2']
+    });
+
+    var sampleRatingScaleQuestion = entityFactory().create(RatingScaleQuestion, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1/question'),
+        questionPosed: 'How satisfied are you with our services?',
+        scale: sampleLikertScale,
+    });
+
+    var sampleQuestionnaireItem = entityFactory().create(QuestionnaireItem, {
+        id: BASE_EDU_IRI.concat('/surveys/100/questionnaires/30/items/1'),
+        question: sampleRatingScaleQuestion,
+        categories: ['teaching effectiveness', 'Course structure'],
+        weight: 1.0
+    });
+
+    // CourseSection (group)
+    var sampleCourseSection = entityFactory().create(CourseSection, {
+      id: BASE_EDU_IRI.concat('/terms/201801/courses/7/sections/1'),
+      courseNumber: 'CPS 435-01',
+      academicSession: 'Fall 2018'
+    });
+
+    // Membership
+    var sampleMembership = entityFactory().create(Membership, {
+      id: sampleCourseSection.id.concat('/rosters/1'),
+      member: samplePerson.id,
+      organization: sampleCourseSection.id,
+      roles: [Role.learner.term],
+      status: Status.active.term,
+      dateCreated: '2018-08-01T06:00:00.000Z'
+    });
+
+    // Session
+    var sampleSession = entityFactory().create(Session, {
+      id: BASE_EDU_IRI.concat('/sessions/f095bbd391ea4a5dd639724a40b606e98a631823'),
+      startedAtTime: '2018-11-12T10:00:00.000Z'
+    });
+
+    // Event
+    var event = eventFactory().create(QuestionnaireItemEvent, {
+      id: 'urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93',
+      actor: samplePerson,
+      action: actions.started.term,
+      object: sampleQuestionnaireItem,
+      eventTime: '2018-11-12T10:15:00.000Z',
+      edApp: BASE_EDU_IRI,
+      group: sampleCourseSection,
+      membership: sampleMembership,
+      session: sampleSession
+    });
+
+    // Compare
+    var diff = testUtils.compare(fixture, clientUtils.parse(event));
+    var diffMsg = 'Validate JSON' + (!_.isUndefined(diff) ? ' diff = ' + clientUtils.stringify(diff) : '');
+
+    t.equal(true, _.isUndefined(diff), diffMsg);
+    //t.end();
+  });
+});

--- a/test/events/surveyEventOptedInTest.js
+++ b/test/events/surveyEventOptedInTest.js
@@ -1,0 +1,101 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var moment = require('moment');
+var test = require('tape');
+
+var config = require('../../src/config/config');
+var eventFactory = require('../../src/events/eventFactory');
+var SurveyEvent = require('../../src/events/surveyEvent');
+var actions = require('../../src/actions/actions');
+
+var entityFactory = require('../../src/entities/entityFactory');
+var CourseSection = require('../../src/entities/agent/courseSection');
+var Membership = require('../../src/entities/agent/membership');
+var Person = require('../../src/entities/agent/person');
+var Role = require('../../src/entities/agent/role');
+var Survey = require('../../src/entities/survey/survey');
+var Session = require('../../src/entities/session/session');
+var Status = require('../../src/entities/agent/status');
+
+var clientUtils = require('../../src/clients/clientUtils');
+var testUtils = require('../testUtils');
+
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEventSurveyOptedIn.json';
+
+testUtils.readFile(path, function(err, fixture) {
+  if (err) throw err;
+
+  test('surveyEventOptedInTest', function (t) {
+
+    // Plan for N assertions
+    t.plan(1);
+
+    var BASE_EDU_IRI = 'https://example.edu';
+
+    // Person (actor)
+    var samplePerson = entityFactory().create(Person, {id: BASE_EDU_IRI.concat('/users/554433')});
+
+    // Survey (object)
+    var sampleSurvey = entityFactory().create(Survey, {id: BASE_EDU_IRI.concat('/survey/1')});
+
+    // CourseSection (group)
+    var sampleCourseSection = entityFactory().create(CourseSection, {
+      id: BASE_EDU_IRI.concat('/terms/201801/courses/7/sections/1'),
+      courseNumber: 'CPS 435-01',
+      academicSession: 'Fall 2018'
+    });
+
+    // Membership
+    var sampleMembership = entityFactory().create(Membership, {
+      id: sampleCourseSection.id.concat('/rosters/1'),
+      member: samplePerson.id,
+      organization: sampleCourseSection.id,
+      roles: [Role.learner.term],
+      status: Status.active.term,
+      dateCreated: '2018-08-01T06:00:00.000Z'
+    });
+
+    // Session
+    var sampleSession = entityFactory().create(Session, {
+      id: BASE_EDU_IRI.concat('/sessions/1f6442a482de72ea6ad134943812bff564a76259'),
+      startedAtTime: '2018-11-15T10:00:00.000Z'
+    });
+
+    // Event
+    var event = eventFactory().create(SurveyEvent, {
+      id: 'urn:uuid:4bfb7726-3564-11e9-b210-d663bd873d93',
+      actor: samplePerson,
+      action: actions.optedIn.term,
+      object: sampleSurvey,
+      eventTime: '2018-11-15T10:05:00.000Z',
+      edApp: BASE_EDU_IRI,
+      group: sampleCourseSection,
+      membership: sampleMembership,
+      session: sampleSession
+    });
+
+    // Compare
+    var diff = testUtils.compare(fixture, clientUtils.parse(event));
+    var diffMsg = 'Validate JSON' + (!_.isUndefined(diff) ? ' diff = ' + clientUtils.stringify(diff) : '');
+
+    t.equal(true, _.isUndefined(diff), diffMsg);
+    //t.end();
+  });
+});

--- a/test/events/surveyInvitationEventAcceptedTest.js
+++ b/test/events/surveyInvitationEventAcceptedTest.js
@@ -1,0 +1,115 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var moment = require('moment');
+var test = require('tape');
+
+var config = require('../../src/config/config');
+var eventFactory = require('../../src/events/eventFactory');
+var SurveyInvitationEvent = require('../../src/events/surveyInvitationEvent');
+var actions = require('../../src/actions/actions');
+
+var entityFactory = require('../../src/entities/entityFactory');
+var CourseSection = require('../../src/entities/agent/courseSection');
+var Membership = require('../../src/entities/agent/membership');
+var Person = require('../../src/entities/agent/person');
+var Role = require('../../src/entities/agent/role');
+var Survey = require('../../src/entities/survey/survey');
+var SurveyInvitation = require('../../src/entities/resource/surveyInvitation');
+var Session = require('../../src/entities/session/session');
+var Status = require('../../src/entities/agent/status');
+
+var clientUtils = require('../../src/clients/clientUtils');
+var testUtils = require('../testUtils');
+
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEventSurveyInvitationAccepted.json';
+
+testUtils.readFile(path, function(err, fixture) {
+  if (err) throw err;
+
+  test('surveyInvitationEventAcceptedTest', function (t) {
+
+    // Plan for N assertions
+    t.plan(1);
+
+    var BASE_EDU_IRI = 'https://example.edu';
+
+    // Person (actor)
+    var personActor = entityFactory().create(Person, {id: BASE_EDU_IRI.concat('/users/554433')});
+
+    // Person (rater)
+    var personRater = entityFactory().create(Person, {id: BASE_EDU_IRI.concat('/users/112233')});
+
+    // Survey
+    var sampleSurvey = entityFactory().create(Survey, {id: BASE_EDU_IRI.concat('/survey/1')});
+
+    // SurveyInvitation (object)
+    var sampleSurveyInvitation = entityFactory().create(SurveyInvitation, {
+        id: BASE_EDU_IRI.concat('/surveys/100/invitations/users/112233'),
+        sentCount: 1,
+        dateSent: '2018-11-15T10:05:00.000Z',
+        rater: personRater,
+        survey: sampleSurvey,
+        dateCreated: '2018-08-01T06:00:00.000Z'
+    });
+
+    // CourseSection (group)
+    var sampleCourseSection = entityFactory().create(CourseSection, {
+      id: BASE_EDU_IRI.concat('/terms/201801/courses/7/sections/1'),
+      courseNumber: 'CPS 435-01',
+      academicSession: 'Fall 2018'
+    });
+
+    // Membership
+    var sampleMembership = entityFactory().create(Membership, {
+      id: sampleCourseSection.id.concat('/rosters/1'),
+      member: personActor.id,
+      organization: sampleCourseSection.id,
+      roles: [Role.learner.term],
+      status: Status.active.term,
+      dateCreated: '2018-08-01T06:00:00.000Z'
+    });
+
+    // Session
+    var sampleSession = entityFactory().create(Session, {
+      id: BASE_EDU_IRI.concat('/sessions/1f6442a482de72ea6ad134943812bff564a76259'),
+      startedAtTime: '2018-11-15T10:00:00.000Z'
+    });
+
+    // Event
+    var event = eventFactory().create(SurveyInvitationEvent, {
+      id: 'urn:uuid:534afa10-3564-11e9-b210-d663bd873d93',
+      actor: personActor,
+      action: actions.accepted.term,
+      object: sampleSurveyInvitation,
+      eventTime: '2018-11-15T10:05:00.000Z',
+      edApp: BASE_EDU_IRI,
+      group: sampleCourseSection,
+      membership: sampleMembership,
+      session: sampleSession
+    });
+
+    // Compare
+    var diff = testUtils.compare(fixture, clientUtils.parse(event));
+    var diffMsg = 'Validate JSON' + (!_.isUndefined(diff) ? ' diff = ' + clientUtils.stringify(diff) : '');
+
+    t.equal(true, _.isUndefined(diff), diffMsg);
+    //t.end();
+  });
+});

--- a/test/events/surveyInvitationEventSentTest.js
+++ b/test/events/surveyInvitationEventSentTest.js
@@ -1,0 +1,115 @@
+/*
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+var _ = require('lodash');
+var moment = require('moment');
+var test = require('tape');
+
+var config = require('../../src/config/config');
+var eventFactory = require('../../src/events/eventFactory');
+var SurveyInvitationEvent = require('../../src/events/surveyInvitationEvent');
+var actions = require('../../src/actions/actions');
+
+var entityFactory = require('../../src/entities/entityFactory');
+var CourseSection = require('../../src/entities/agent/courseSection');
+var Membership = require('../../src/entities/agent/membership');
+var Person = require('../../src/entities/agent/person');
+var Role = require('../../src/entities/agent/role');
+var Survey = require('../../src/entities/survey/survey');
+var SurveyInvitation = require('../../src/entities/resource/surveyInvitation');
+var Session = require('../../src/entities/session/session');
+var Status = require('../../src/entities/agent/status');
+
+var clientUtils = require('../../src/clients/clientUtils');
+var testUtils = require('../testUtils');
+
+var path = config.testFixturesBaseDir.v1p1 + 'caliperEventSurveyInvitationSent.json';
+
+testUtils.readFile(path, function(err, fixture) {
+  if (err) throw err;
+
+  test('surveyInvitationEventSentTest', function (t) {
+
+    // Plan for N assertions
+    t.plan(1);
+
+    var BASE_EDU_IRI = 'https://example.edu';
+
+    // Actor
+    var personActor = entityFactory().create(Person, {id: BASE_EDU_IRI.concat('/users/112233')});
+
+    // Rater
+    var personRater = entityFactory().create(Person, {id: BASE_EDU_IRI.concat('/users/554433')});
+
+    // Survey
+    var sampleSurvey = entityFactory().create(Survey, {id: BASE_EDU_IRI.concat('/survey/1')});
+
+    // SurveyInvitation (object)
+    var sampleSurveyInvitation = entityFactory().create(SurveyInvitation, {
+        id: BASE_EDU_IRI.concat('/surveys/100/invitations/users/554433'),
+        sentCount: 1,
+        dateSent: '2018-11-15T10:05:00.000Z',
+        rater: personRater,
+        survey: sampleSurvey,
+        dateCreated: '2018-08-01T06:00:00.000Z'
+    });
+
+    // CourseSection (group)
+    var sampleCourseSection = entityFactory().create(CourseSection, {
+      id: BASE_EDU_IRI.concat('/terms/201801/courses/7/sections/1'),
+      courseNumber: 'CPS 435-01',
+      academicSession: 'Fall 2018'
+    });
+
+    // Membership
+    var sampleMembership = entityFactory().create(Membership, {
+      id: sampleCourseSection.id.concat('/rosters/1'),
+      member: personActor.id,
+      organization: sampleCourseSection.id,
+      roles: [Role.instructor.term],
+      status: Status.active.term,
+      dateCreated: '2018-08-01T06:00:00.000Z'
+    });
+
+    // Session
+    var sampleSession = entityFactory().create(Session, {
+      id: BASE_EDU_IRI.concat('/sessions/f095bbd391ea4a5dd639724a40b606e98a631823'),
+      startedAtTime: '2018-11-12T10:00:00.000Z'
+    });
+
+    // Event
+    var event = eventFactory().create(SurveyInvitationEvent, {
+      id: 'urn:uuid:5801f73e-3564-11e9-b210-d663bd873d93',
+      actor: personActor,
+      action: actions.sent.term,
+      object: sampleSurveyInvitation,
+      eventTime: '2018-11-12T10:15:00.000Z',
+      edApp: BASE_EDU_IRI,
+      group: sampleCourseSection,
+      membership: sampleMembership,
+      session: sampleSession
+    });
+
+    // Compare
+    var diff = testUtils.compare(fixture, clientUtils.parse(event));
+    var diffMsg = 'Validate JSON' + (!_.isUndefined(diff) ? ' diff = ' + clientUtils.stringify(diff) : '');
+
+    t.equal(true, _.isUndefined(diff), diffMsg);
+    //t.end();
+  });
+});


### PR DESCRIPTION
This PR includes the remaining entities (6), events (4), actions, and tests associated with the Survey Profile. Three tests were also written for preexisting entities (Response, Question, and RatingScaleQuestion). In addition, modifications were also made to sensor.js, entityType.js, and eventType.js. Two fixtures associated with QuestionnaireEvent and QuestionnaireItemEvent did not receive tests, due to (what I believe) were mistakes related to the actions used (I will follow up by email).